### PR TITLE
Fix a bug where the DataGrid don't work if the controller is not directly in the App\Http\Controllers\ namespace.

### DIFF
--- a/src/Datagrid.php
+++ b/src/Datagrid.php
@@ -545,12 +545,9 @@ class Datagrid {
      */
     public static function getCurrentRouteLink($get_params = []) {
         $current_action = \Illuminate\Support\Facades\Route::current()->getAction();
-        $controller = $current_action['controller'];
-        $namespace = $current_action['namespace'];
+        $controller = '\\' . $current_action['controller'];
         $parameters = \Illuminate\Support\Facades\Route::current()->parameters();
 
-        $controller_namespace_stripped = trim(str_replace($namespace, '', $controller), '\\');
-
-        return action($controller_namespace_stripped, $parameters) . ($get_params ? '?' . http_build_query($get_params) : '');
+        return action($controller, $parameters) . ($get_params ? '?' . http_build_query($get_params) : '');
     }
 }


### PR DESCRIPTION
If for example the controllers are placed under `App\Http\Controllers\Admin\` namespace the package is not working, because it try to find the controller in the default namespace `App\Http\Controllers\Admin\`.
