### PR TITLE
Add sorting support for dot notation column names

### DIFF
--- a/src/Datagrid.php
+++ b/src/Datagrid.php
@@ -120,7 +120,17 @@ class Datagrid {
 	 * @return Collection
 	 */
 	public function getRows() {
-		return $this->rows;
+		$sort_params = clone $this->getFilters(false);
+		$rows = $this->rows->sortBy(function ($row) use ($sort_params) {
+			$params = explode('.', $sort_params['order_by']);
+			$obj = $row;
+			foreach($params as $key => $param) {
+				$obj = $obj->{$param};
+			}
+			return $obj;
+		}, SORT_REGULAR, $sort_params['order_dir'] === 'DESC');
+
+		return $rows;
 	}
 
 	/**

--- a/src/Datagrid.php
+++ b/src/Datagrid.php
@@ -121,15 +121,19 @@ class Datagrid {
 	 */
 	public function getRows() {
 		$sort_params = clone $this->getFilters(false);
-		$rows = $this->rows->sortBy(function ($row) use ($sort_params) {
-			$params = explode('.', $sort_params['order_by']);
-			$obj = $row;
-			foreach($params as $key => $param) {
-				$obj = $obj->{$param};
-			}
-			return $obj;
-		}, SORT_REGULAR, $sort_params['order_dir'] === 'DESC');
-
+		$rows = $this->rows;
+		if (isset($sort_params['order_by']) && trim($sort_params['order_by']) !== ''
+				&& isset($sort_params['order_dir']))
+		{
+			$rows = $rows->sortBy(function ($row) use ($sort_params) {
+				$params = explode('.', $sort_params['order_by']);
+				$obj = $row;
+				foreach($params as $key => $param) {
+					$obj = $obj->{$param};
+				}
+				return $obj;
+			}, SORT_REGULAR, $sort_params['order_dir'] === 'DESC');
+		}
 		return $rows;
 	}
 

--- a/src/Datagrid.php
+++ b/src/Datagrid.php
@@ -124,7 +124,7 @@ class Datagrid {
 		$rows = $this->rows;
 
 		// filter rows
-		$just_filters = $filters;
+		$just_filters = clone $filters;
 		unset($just_filters['order_by']);
 		unset($just_filters['order_dir']);
 		$non_empty_filter = array_filter((array)$just_filters->all());
@@ -150,7 +150,7 @@ class Datagrid {
 			});
 
 		// sort rows
-		if (isset($filter_params['order_by']) && trim($filters['order_by']) !== ''
+		if (isset($filters['order_by']) && trim($filters['order_by']) !== ''
 				&& isset($filters['order_dir']))
 		{
 			$rows = $rows->sortBy(function ($row) use ($filters) {


### PR DESCRIPTION
Sorting was not working.  I think it's because sortBy only works with arrays.  Here's a way to make sorting work even for dot notation columns. Eg. User->post->subject with column User.post.name.
